### PR TITLE
Old values for procs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ Consider finding key's position in a sorted array:
 
 The first loop invariant is rather obvious. The other one is also
 intuitive if we know this module uses '`' character meaning roundly
-"previously" (in last iteration or yield). Actually, we could
+"previously" (in last iteration or yield, can also be used in postconditions
+to refer to values seen by preconditions). Actually, we could
 strengthen our invariants by adding information about how fast
 the range shrinks but it's not necessary to prove the algorithm
 works (although it is needed to prove how efficient it is).
@@ -184,6 +185,12 @@ numerical value:
 - 2: Basic --- show both source and final code
 - 3: Verbose --- as Basic + show each type
     of contract detected for the entity (directly or indirectly).
+
+## Non-obvious goodies
+Nim has an undocumented problem with JS `deepCopy` implementation lacking.
+Contracts uses its own implementation of `deepCopy` for JS backend, thus
+solving the problem. Thanks to that, "previous values" can be used on JS
+backend just like on C or C++ ones.
 
 
 ## Future

--- a/contracts/contexts/contextType.nim
+++ b/contracts/contexts/contextType.nim
@@ -46,6 +46,7 @@ type Context = ref object
    sections: Table[Keyword, NimNode]  # sections
    original: NimNode  # original source
    final:    NimNode  # final code
+   olds: NimNode      # old/previous values
 
 
 # forward-declaration

--- a/contracts/contexts/deepCopyPolyfill.js
+++ b/contracts/contexts/deepCopyPolyfill.js
@@ -1,0 +1,20 @@
+function __native_deepCopy(from, to) {
+  if (from == null || typeof from != "object") {
+    return from;
+  }
+  if (from.constructor != Object && from.constructor != Array) {
+    return from;
+  }
+  if (from.constructor == Date || from.constructor == RegExp || from.constructor == Function ||
+    from.constructor == String || from.constructor == Number || from.constructor == Boolean) {
+    return new from.constructor(from);
+  }
+
+  to = to || new from.constructor();
+
+  for (var name in from) {
+    to[name] = typeof to[name] == "undefined" ? __native_deepCopy(from[name], null) : to[name];
+  }
+
+  return to;
+}

--- a/contracts/contexts/deepCopyPolyfill.nim
+++ b/contracts/contexts/deepCopyPolyfill.nim
@@ -1,0 +1,19 @@
+when declared(deepCopy):
+  template systemDeepCopy*(y): untyped = system.deepCopy(y)
+  template systemDeepCopy*(x, y) = system.deepCopy(x, y)
+elif defined(js):
+  const deepCopyPolyfill = staticRead("deepCopyPolyfill.js")
+  {.emit: deepCopyPolyfill.}
+
+  proc deepCopy[T](x: var T, y: T) {.importc: "__native_deepCopy".}
+  proc deepCopy[T](y: T): T {.importc: "__native_deepCopy".}
+  
+  {.hint: "Target JS lacks deepCopy. Custom implementation used instead.".}
+
+  template systemDeepCopy*(y): untyped = deepCopy(y)
+  template systemDeepCopy*(x, y) = deepCopy(x, y)
+else:
+  {.error: "Target does not support deepCopy, shallow copy used instead!".}
+  template systemDeepCopy*(y): untyped = y
+  template systemDeepCopy*(x, y) =
+    x = y

--- a/contracts/contexts/handleContext.nim
+++ b/contracts/contexts/handleContext.nim
@@ -8,15 +8,18 @@ proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
            PreConditionError.name.ident, ct.pre)
 
       if ct.post != nil:
-         let preparationNode = getOldValues(ct.post)
+         let preparationNode = getOldValues(ct.post).reduceOldValues
          let postCondNode = contractInstance(
            PostConditionError.name.ident, ct.post)
          ct.post = newTree(nnkDefer, postCondNode)
-         ct.head.add preparationNode.reduceOldValues
+         ct.olds = preparationNode
 
       ct.handler()  # notice invariant MUST be included in impl!
 
       result = newStmtList(ct.head)
+
+      if ct.olds != nil:
+         result.add ct.olds
 
       if ct.pre != nil:
          result.add ct.pre

--- a/contracts/contexts/handlers/conProc.nim
+++ b/contracts/contexts/handlers/conProc.nim
@@ -7,7 +7,14 @@ proc proceduralContract(thisNode: NimNode): NimNode =
   ## Handles contracts for procedures and converters.
   contextHandle(thisNode, @ContractKeywordsProc) do (it: Context):
     if it.olds != nil:
-      let li = newStmtList()
-      li.add it.olds
-      li.add updateOldValues(it.olds)
-      it.olds = li
+      if it.olds.kind == nnkVarSection:
+        let new_olds = newNimNode(nnkLetSection)
+        for i, section in it.olds:
+          # `var name: type(impl)` --> `let name = impl`
+          let name = section[0]
+          let type_src = section[1][1]
+          template systemDeepCopy(n): untyped = system.deepCopy(n)
+          let impl = getAst(systemDeepCopy(type_src))
+          let new_section = newIdentDefs(name, newEmptyNode(), impl)
+          new_olds.add new_section
+        it.olds = new_olds

--- a/contracts/contexts/handlers/conProc.nim
+++ b/contracts/contexts/handlers/conProc.nim
@@ -2,7 +2,12 @@
 #
 # Procedures and converters
 #
+
 proc proceduralContract(thisNode: NimNode): NimNode =
   ## Handles contracts for procedures and converters.
   contextHandle(thisNode, @ContractKeywordsProc) do (it: Context):
-    discard
+    if it.olds != nil:
+      let li = newStmtList()
+      li.add it.olds
+      li.add updateOldValues(it.olds)
+      it.olds = li

--- a/contracts/contexts/handlers/conProc.nim
+++ b/contracts/contexts/handlers/conProc.nim
@@ -3,6 +3,8 @@
 # Procedures and converters
 #
 
+import ../deepCopyPolyfill
+
 proc proceduralContract(thisNode: NimNode): NimNode =
   ## Handles contracts for procedures and converters.
   contextHandle(thisNode, @ContractKeywordsProc) do (it: Context):
@@ -13,7 +15,6 @@ proc proceduralContract(thisNode: NimNode): NimNode =
           # `var name: type(impl)` --> `let name = impl`
           let name = section[0]
           let type_src = section[1][1]
-          template systemDeepCopy(n): untyped = system.deepCopy(n)
           let impl = getAst(systemDeepCopy(type_src))
           let new_section = newIdentDefs(name, newEmptyNode(), impl)
           new_olds.add new_section

--- a/contracts/contexts/oldValueBinding.nim
+++ b/contracts/contexts/oldValueBinding.nim
@@ -53,7 +53,9 @@ proc updateOldValues(thisNode: NimNode): NimNode =
     for child in thisNode.children:
       let name = child[0]
       let value = child[1][1]
-      result.add newCall(bindSym"deepCopy", name, value)
+      template updateSingle(name, value) =
+        system.deepCopy(name, value)
+      result.add getAst(updateSingle(name, value))
   else:
     result = newEmptyNode()
 

--- a/contracts/contexts/oldValueBinding.nim
+++ b/contracts/contexts/oldValueBinding.nim
@@ -2,6 +2,9 @@
 # Bind old values with escaping
 #
 
+import deepCopyPolyfill
+
+
 proc oldValIdentToStr(thisNode: NimNode): string =
   ## Changes old value's identifier to string
   result = "`"
@@ -53,9 +56,7 @@ proc updateOldValues(thisNode: NimNode): NimNode =
     for child in thisNode.children:
       let name = child[0]
       let value = child[1][1]
-      template updateSingle(name, value) =
-        system.deepCopy(name, value)
-      result.add getAst(updateSingle(name, value))
+      result.add getAst(systemDeepCopy(name, value))
   else:
     result = newEmptyNode()
 


### PR DESCRIPTION
Adds proper support for old values to proc context.
* every old value used adds a single `let` binding to the old value
* values are bind before any of the "body" instructions modify them
* `deepCopy` is used to ensure the old values remain untouched. Note: for JS target, there is a [known issue](https://github.com/nim-lang/Nim/issues/4631) about the implementation of `deepCopy` lacking despite not being included on the [list of features not supported on JS target](https://nim-lang.org/docs/backends.html#backends-the-javascript-target). Because of that, a custom implementation of `deepCopy` has been provided for JS target.