### PR TITLE
Safe polyfills

### DIFF
--- a/contracts/contexts/deepCopyPolyfill.nim
+++ b/contracts/contexts/deepCopyPolyfill.nim
@@ -13,7 +13,13 @@ elif defined(js):
   template systemDeepCopy*(y): untyped = deepCopy(y)
   template systemDeepCopy*(x, y) = deepCopy(x, y)
 else:
-  {.warning: "Target does not support deepCopy, shallow copy used instead!".}
-  template systemDeepCopy*(y): untyped = y
+  {.warning:
+    "Target does not support deepCopy. 'Old values' feature cannot be used."
+  .}
+
+  template systemDeepCopy*(y): untyped =
+    error: "Target does not support deepCopy, but 'old values' used!"
+    y
   template systemDeepCopy*(x, y) =
+    error: "Target does not support deepCopy, but 'old values' used!".
     x = y

--- a/contracts/contexts/deepCopyPolyfill.nim
+++ b/contracts/contexts/deepCopyPolyfill.nim
@@ -13,7 +13,7 @@ elif defined(js):
   template systemDeepCopy*(y): untyped = deepCopy(y)
   template systemDeepCopy*(x, y) = deepCopy(x, y)
 else:
-  {.error: "Target does not support deepCopy, shallow copy used instead!".}
+  {.warning: "Target does not support deepCopy, shallow copy used instead!".}
   template systemDeepCopy*(y): untyped = y
   template systemDeepCopy*(x, y) =
     x = y


### PR DESCRIPTION
Make pollyfilling safe:
* no implicit `deepCopy` --> `shallowCopy` conversion (not safe, misleading)
* no hard error on usage of no-`deepCopy` backend (such as NimVM), just a warning
* hard error on using features that need `deepCopy` when it isn't available