### PR TITLE
fix: compiling a code when assertions are disabled

### DIFF
--- a/contracts/contexts/handleContext.nim
+++ b/contracts/contexts/handleContext.nim
@@ -1,14 +1,11 @@
 proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
    ct.explainContractBefore()
-
    ct.handler()  # notice invariant MUST be included in impl!
 
    result = newStmtList(ct.head)
+   let docs = ct.genDocs()
 
    ghost do:
-
-      let docs = ct.genDocs()
-
       if ct.pre != nil:
          ct.pre = contractInstance(
            ident(PreConditionDefect.name), ct.pre)
@@ -28,23 +25,16 @@ proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
 
       if ct.post != nil:  # using defer
          result.add ct.post
-
-      # add generated docs and generate it in the code
-      if ct.kind != EntityKind.blocklike:
-         ct.docsNode.add2docs(docs)
-         result.docs2body(ct.docsNode)
-
    do:
-
       if ct.olds != nil:
          result.add ct.olds
 
-      # generate docs in the code
-      if ct.kind != EntityKind.blocklike:
-         result.docs2body(ct.docsNode)
+   # add generated docs and generate it in the code
+   if ct.kind != EntityKind.blocklike:
+      ct.docsNode.add2docs(docs)
+      result.docs2body(ct.docsNode)
 
    let stmtsIdx = ct.tail.findChildIdx(it.kind == nnkStmtList)
-
    ct.tail[stmtsIdx] = findContract(ct.impl)
 
    if ct.kind == EntityKind.declaration:
@@ -59,7 +49,6 @@ proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
          result = newBlockStmt(result)
 
    ct.final = result
-
    ct.explainContractAfter()
 
 proc contextHandle(code: NimNode,

--- a/contracts/contexts/handleContext.nim
+++ b/contracts/contexts/handleContext.nim
@@ -1,7 +1,13 @@
 proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
+   ct.explainContractBefore()
+
+   ct.handler()  # notice invariant MUST be included in impl!
+
+   result = newStmtList(ct.head)
+
    ghost do:
+
       let docs = ct.genDocs()
-      ct.explainContractBefore()
 
       if ct.pre != nil:
          ct.pre = contractInstance(
@@ -14,10 +20,6 @@ proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
          ct.post = newTree(nnkDefer, postCondNode)
          ct.olds = preparationNode
 
-      ct.handler()  # notice invariant MUST be included in impl!
-
-      result = newStmtList(ct.head)
-
       if ct.olds != nil:
          result.add ct.olds
 
@@ -27,32 +29,38 @@ proc handle(ct: Context, handler: proc(ct: Context) {.closure.}): NimNode =
       if ct.post != nil:  # using defer
          result.add ct.post
 
-      let stmtsIdx = ct.tail.findChildIdx(it.kind == nnkStmtList)
-      ct.tail[stmtsIdx] = findContract(ct.impl)
-
-      if ct.kind == EntityKind.declaration:
-        let tmp = ct.tail[stmtsIdx]
-        ct.tail[stmtsIdx] = newStmtList(result, tmp)
-        result = ct.tail
-      else:
-        result.add ct.tail
-
-        if ct.kind == EntityKind.blocklike:
-          # for `defer` to work properly:
-          result = newBlockStmt(result)
-
       # add generated docs and generate it in the code
       if ct.kind != EntityKind.blocklike:
-        ct.docsNode.add2docs(docs)
-        result.docs2body(ct.docsNode)
-
-      ct.final = result
-      ct.explainContractAfter()
+         ct.docsNode.add2docs(docs)
+         result.docs2body(ct.docsNode)
 
    do:
-      let stmtsIdx = ct.tail.findChildIdx(it.kind == nnkStmtList)
-      result[stmtsIdx] = findContract(ct.impl)
 
+      if ct.olds != nil:
+         result.add ct.olds
+
+      # generate docs in the code
+      if ct.kind != EntityKind.blocklike:
+         result.docs2body(ct.docsNode)
+
+   let stmtsIdx = ct.tail.findChildIdx(it.kind == nnkStmtList)
+
+   ct.tail[stmtsIdx] = findContract(ct.impl)
+
+   if ct.kind == EntityKind.declaration:
+      let tmp = ct.tail[stmtsIdx]
+      ct.tail[stmtsIdx] = newStmtList(result, tmp)
+      result = ct.tail
+   else:
+      result.add ct.tail
+
+      if ct.kind == EntityKind.blocklike:
+         # for `defer` to work properly:
+         result = newBlockStmt(result)
+
+   ct.final = result
+
+   ct.explainContractAfter()
 
 proc contextHandle(code: NimNode,
                    sections: openArray[Keyword],


### PR DESCRIPTION
When trying to compile a code, which uses NimContracts with Nim 1.6.6 and with disabled assertions, compilations fails on generating the final code. The problem is in the line: 

https://github.com/Udiknedormin/NimContracts/blob/main/contracts/contexts/handleContext.nim#L54

`result` there is initialized with the default value, `nnkNilLit` not with the proper one, that's why it crashes. I rewrote the procedure `handle` so it **should** now work also when assertions are disabled. But it may need some tests, especially with `ghost` code. I tested only with pre- and post-conditions.

I was trying to keep it in the current coding style, but if something is wrong, please tell me, I will fix it.