### PR TITLE
no checks for release mode; even for Nim 1.6.0 (Issue #18)

### DIFF
--- a/contracts.nimble
+++ b/contracts.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.1"
+version       = "0.2.2"
 author        = "M. Kotwica"
 description   = "Design by contract (DbC) library."
 license       = "MIT"

--- a/contracts/features/ghostCode.nim
+++ b/contracts/features/ghostCode.nim
@@ -5,11 +5,12 @@
 template ghostly(): untyped =
   ## The conditions which should be fulfilled for ghost code
   ## to be turned on.
-  compileOption("assertions")
+  (not defined(release)) and compileOption("assertions")
 
 template ghost*(code: untyped): untyped =
   ## Marks `ghost code`, only used for tests and static analysis.
-  ## It can be turned on or off by ``assertions`` compiler flag.
+  ## It can be turned off by using the ``-d:release`` mode or
+  ## turning the ``assertions`` compiler flag to "off" state.
   ## Example:
   ##
   ## .. code-block:: nim


### PR DESCRIPTION
Fixes issue #18.

Nim 1.6.0 changed the default behaviour of assertions in the release mode: they are "on" by default. Since NimContracts was relying on that behaviour, it's quite of a big change and may be controversial.

Because of that, `ghostly` will check not only for "assertions" flag, but also "release" mode.